### PR TITLE
Be sure to distinct things when fetching a single object.

### DIFF
--- a/pkg/postgres/functions.go
+++ b/pkg/postgres/functions.go
@@ -40,7 +40,8 @@ func (c *Client) GetFunction(ctx context.Context, functionID int64) (*FunctionMo
 	ret := &FunctionModel{}
 
 	q := `
-SELECT a."oid"::int, a."proname",
+SELECT DISTINCT 
+       a."oid"::int, a."proname",
        n."nspname",
        a."proowner"::int, a."proacl"
 FROM "pg_catalog"."pg_proc" a

--- a/pkg/postgres/procedures.go
+++ b/pkg/postgres/procedures.go
@@ -40,7 +40,9 @@ func (c *Client) GetProcedure(ctx context.Context, functionID int64) (*Procedure
 	ret := &ProcedureModel{}
 
 	q := `
-SELECT a."oid"::int, a."proname",
+SELECT DISTINCT
+       a."oid"::int,
+       a."proname",
        n."nspname",
        a."proowner"::int, a."proacl"
 FROM "pg_catalog"."pg_proc" a

--- a/pkg/postgres/roles.go
+++ b/pkg/postgres/roles.go
@@ -81,7 +81,8 @@ WHERE r."rolname" = $1
 
 func (c *Client) GetRole(ctx context.Context, roleID int64) (*RoleModel, error) {
 	q := `
-SELECT r."rolname",
+SELECT DISTINCT
+       r."rolname",
        r."rolsuper",
        r."rolinherit",
        r."rolcreaterole",

--- a/pkg/postgres/tables.go
+++ b/pkg/postgres/tables.go
@@ -38,12 +38,7 @@ func (t *TableModel) DefaultPrivileges() PrivilegeSet {
 func (c *Client) GetTable(ctx context.Context, tableID int64) (*TableModel, error) {
 	ret := &TableModel{}
 
-	q := `
-SELECT c."oid"::int, c."relname", c."relowner"::int, n."nspname", c."relacl"
-FROM pg_class c
-         LEFT JOIN pg_namespace n ON n."oid" = c."relnamespace"
-WHERE c."oid" = $1
-`
+	q := c.getClassQuery(ctx)
 
 	err := pgxscan.Get(ctx, c.db, ret, q, tableID)
 	if err != nil {

--- a/pkg/postgres/views.go
+++ b/pkg/postgres/views.go
@@ -38,12 +38,7 @@ func (t *ViewModel) DefaultPrivileges() PrivilegeSet {
 func (c *Client) GetView(ctx context.Context, viewID int64) (*ViewModel, error) {
 	ret := &ViewModel{}
 
-	q := `
-SELECT c."oid"::int, c."relname", c."relowner"::int, n."nspname", c."relacl"
-FROM pg_class c
-         LEFT JOIN pg_namespace n ON n."oid" = c."relnamespace"
-WHERE c."oid" = $1
-`
+	q := c.getClassQuery(ctx)
 
 	err := pgxscan.Get(ctx, c.db, ret, q, viewID)
 	if err != nil {


### PR DESCRIPTION
Specifically when fetching roles, because we are joining to also collect the members of the role, it is possible for duplicate rows to be returned. Use distinct to make sure we only get a single row back.