### PR TITLE
AccountCreationSchema DisplayNames should be titlecase

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -42,7 +42,7 @@ func (c *Postgresql) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
 				"email": {
-					DisplayName: "email",
+					DisplayName: "Email",
 					Required:    true,
 					Description: "This email will be used as the login for the user.",
 					Field:       &v2.ConnectorAccountCreationSchema_Field_StringField{},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated display name for email field to use proper capitalization ("Email" instead of "email")

<!-- end of auto-generated comment: release notes by coderabbit.ai -->