### PR TITLE
[DUCT-10035] Allow connector to use email field from account provisioning schema

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -367,7 +367,16 @@ func (r *roleSyncer) CreateAccount(
 		Name:  "password",
 		Bytes: []byte(plainTextPassword),
 	}
-	roleModel, err = r.client.CreateUser(ctx, accountInfo.GetLogin(), plainTextPassword)
+	// Default to C1 User's login as email
+	email := accountInfo.GetLogin()
+	// If the account provisioning schema has been filled, use the calculated email field
+	if accountInfo.Profile != nil {
+		profileMap := accountInfo.Profile.GetFields()
+		if value, ok := profileMap["email"]; ok && value.GetStringValue() != "" {
+			email = value.GetStringValue()
+		}
+	}
+	roleModel, err = r.client.CreateUser(ctx, email, plainTextPassword)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
https://conductorone.atlassian.net/browse/DUCT-10035

Currently, account provisioning just uses the requestor's main email and does not respect the CEL expression in the account provisioning schema. If that field is available and has been evaluated to a non-empty string, we should use that instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved account creation by prioritizing a user’s profile email (when provided) over the default login value, ensuring more accurate communication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->