### PR TITLE
fix(postgres): close per-schema typeRows inside the iteration

### DIFF
--- a/pkg/postgres/roles.go
+++ b/pkg/postgres/roles.go
@@ -288,6 +288,10 @@ func (c *Client) RevokeAllGrantsFromRole(ctx context.Context, roleName string) e
 					revokeError = errors.Join(revokeError, err)
 				}
 			}
+			if err := typeRows.Err(); err != nil {
+				l.Warn("error iterating types", zap.String("schema", schema), zap.Error(err))
+				revokeError = errors.Join(revokeError, err)
+			}
 			typeRows.Close()
 		}
 

--- a/pkg/postgres/roles.go
+++ b/pkg/postgres/roles.go
@@ -272,8 +272,6 @@ func (c *Client) RevokeAllGrantsFromRole(ctx context.Context, roleName string) e
 			l.Warn("error querying types", zap.String("schema", schema), zap.Error(err))
 			revokeError = errors.Join(revokeError, err)
 		} else {
-			defer typeRows.Close()
-
 			for typeRows.Next() {
 				var typeName string
 				if err := typeRows.Scan(&typeName); err != nil {
@@ -290,6 +288,7 @@ func (c *Client) RevokeAllGrantsFromRole(ctx context.Context, roleName string) e
 					revokeError = errors.Join(revokeError, err)
 				}
 			}
+			typeRows.Close()
 		}
 
 		revokeSchemaQuery := fmt.Sprintf("REVOKE ALL ON SCHEMA %s FROM %s", sanitizedSchema, sanitizedRoleName)


### PR DESCRIPTION
\`RevokeAllGrantsFromRole\` iterates schemas and, for each schema, queries the database type list via \`typeRows\`. The \`Close\` was registered with \`defer\`, but \`defer\` fires only on FUNCTION return, not iteration return -- so each schema iteration accumulated a pending \`typeRows.Close\`, and the underlying sql connections were held until the outer function returned. On a database with many schemas this exhausts the connection pool.

Replaced the deferred \`Close\` with an explicit \`Close\` after the inner \`for typeRows.Next()\` loop completes. Iteration semantics are unchanged: \`typeRows.Close\` on a fully-consumed \`Rows\` is safe, and the error path didn't reach the Close anyway (the \`err != nil\` branch records the error and falls through without opening \`typeRows\`).

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`defer_in_loop_close\`.