### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -32,7 +32,7 @@ Configuring the connector requires you to pass in credentials generated in Postg
 
 - The DSN used to connect to the PostgreSQL database
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the PostgreSQL connector
 
@@ -172,6 +172,6 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the PostgreSQL connector to. PostgreSQL data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your PostgreSQL connector is now pulling access data into C1.
+**Done.** Your PostgreSQL connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.