### PR TITLE
fix: mark dsn as isSecret in config schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	dsn                  = field.StringField("dsn", field.WithRequired(true), field.WithDescription("The DSN to connect to the database"))
+	dsn                  = field.StringField("dsn", field.WithRequired(true), field.WithDescription("The DSN to connect to the database"), field.WithIsSecret(true))
 	schemas              = field.StringSliceField("schemas", field.WithDefaultValue([]string{"public"}), field.WithDescription("The schemas to include in the sync"))
 	includeColumns       = field.BoolField("include-columns", field.WithDescription("Include column privileges when syncing. This can result in large amounts of data"))
 	includeLargeObjects  = field.BoolField("include-large-objects", field.WithDescription("Include large objects when syncing. This can result in large amounts of data"))


### PR DESCRIPTION
## Summary

Marks credential field(s) `dsn` (the DSN connection string embeds the database password) as secret in this connector's config so the credential is stored and handled as a secret rather than plaintext.

This connector defines its config in Go (`field` package), not a `config.yaml`. Secret-ness is the `field.WithIsSecret(true)` option on the field — the authoritative source. There is no committed `config_schema.json` in this repo, and the generated `conf.gen.go` is a mapstructure struct that carries no secret metadata, so the one-line `config.go` change is the complete fix and a CI regen produces no additional diff (no race).

## BREAKING

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

## Audit

Part of the connector config secret-ness audit (phase 13). Found via systematic review of credential fields lacking `isSecret`.

Do not merge — left open for review.

<!-- stargate: connector-secret-audit-phase13 -->